### PR TITLE
chore: add an empty environmentVariables object to ava configuration in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
   },
   "ava": {
     "typescript": {
+      "environmentVariables": {},
       "rewritePaths": {
         "src/": "dist/"
       },


### PR DESCRIPTION
While going through https://stedi.slab.com/posts/deploying-core-event-to-webhook-function-k0gme2jc customers may end up making a typo when adding `environmentVariables` to their `ava` config.

This PR ensures that an empty `environmentVariables` object is always present and as described in the doc (step 6), customers need to only add a `WEBHOOK_URL` entry.