### PR TITLE
fix: move environmentVariables key to top-level field in ava config

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,8 +83,8 @@
     "useTabs": false
   },
   "ava": {
+    "environmentVariables": {},
     "typescript": {
-      "environmentVariables": {},
       "rewritePaths": {
         "src/": "dist/"
       },


### PR DESCRIPTION
Fixing an issue introduced in https://github.com/Stedi-Demos/integrations-sdk/pull/2, `environmentVariables` is a top level key in `ava` config.