### PR TITLE
fix: remove `--no-warnings` to unblock cross-platform customers

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --no-warnings
+#!/usr/bin/env node
 
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";


### PR DESCRIPTION
Passing node arguments in the shebang line is causing issues for our customers on Windows and Linux.

There's a way to pass these arguments as plain CLI args, but that would require some refactoring. To unblock our customer, we are removing the `--no-warnings` argument for now and work on adding it back in cross-platform way separately.