### PR TITLE
feat: add migrate-sftp-user command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stedi/integrations-sdk",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stedi/integrations-sdk",
-      "version": "0.1.27",
+      "version": "0.1.28",
       "license": "ISC",
       "bin": {
         "stedi-integrations": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stedi/integrations-sdk",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "description": "Stedi Integrations SDK",
   "type": "module",
   "scripts": {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,5 +1,6 @@
 import * as deploy from "./deploy.js";
 import * as installTemplate from "./install-template.js";
+import * as migrateSftpUser from "./migrate-sftp-user.js";
 import * as newFunction from "./new-function.js";
 
-export const commands = [deploy, installTemplate, newFunction];
+export const commands = [deploy, installTemplate, migrateSftpUser, newFunction];

--- a/src/commands/migrate-sftp-user.ts
+++ b/src/commands/migrate-sftp-user.ts
@@ -1,0 +1,59 @@
+import { partnersClient, sftpClient } from "../clients/index.js";
+import { UpdateUserCommand } from "@stedi/sdk-client-sftp";
+import { CreateStediFtpConnectionCommand } from "@stedi/sdk-client-partners";
+import { resolveAccountId } from "../common/resolve-account-id.js";
+
+export const command =
+  "migrate-sftp-user <sftp-username> <partnership-id> [inbound-directory] [outbound-directory]";
+
+export const desc = "Migrates existing SFTP user to Core Stedi SFTP connection";
+
+export const builder = {};
+
+export const handler = async (argv: {
+  sftpUsername: string;
+  partnershipId: string;
+  inboundDirectory?: string;
+  outboundDirectory?: string;
+}) => {
+  const stediAccountId = await resolveAccountId();
+  const sftpUsername = argv.sftpUsername;
+  const partnershipId = argv.partnershipId;
+  const inboundDirectoryOverride = argv.inboundDirectory;
+  const outboundDirectoryOverride = argv.outboundDirectory;
+
+  // update existing SFTP user
+  const bucketName = `${stediAccountId}-core-sftp`;
+  const defaultCoreSftpRoot = "/partnerships";
+  const homeDirectory = `${defaultCoreSftpRoot}/${partnershipId}`;
+  const description = `Stedi SFTP User for Partnership ${partnershipId}`;
+
+  const sftpUser = await sftpClient().send(
+    new UpdateUserCommand({
+      username: sftpUsername,
+      bucketName,
+      homeDirectory,
+      description,
+    })
+  );
+
+  console.log(`update user result: ${JSON.stringify(sftpUser, null, 2)}`);
+
+  // create core connection using updated SFTP user
+  const sftpConnection = await partnersClient().send(
+    new CreateStediFtpConnectionCommand({
+      name: `${partnershipId} SFTP`,
+      inboundSubdirectory: inboundDirectoryOverride ?? "/inbound",
+      outboundSubdirectory: outboundDirectoryOverride ?? "/outbound",
+      deleteInboundFilesOnReceipt: true,
+      username: sftpUsername,
+      bucketName,
+      homeDirectory,
+      partnershipId,
+    })
+  );
+
+  console.log(
+    `create connection result: ${JSON.stringify(sftpConnection, null, 2)}`
+  );
+};

--- a/src/common/resolve-account-id.ts
+++ b/src/common/resolve-account-id.ts
@@ -1,0 +1,21 @@
+import { credsClient } from "../clients/credentials.js";
+import { GetAwsAccessCommand } from "@stedi/sdk-client-exchange-credentials";
+
+export const resolveAccountId = async (): Promise<string> => {
+  const response = await credsClient().send(new GetAwsAccessCommand({}));
+  if (response.webIdentityToken === undefined)
+    throw new Error("failure trying to authenticate");
+
+  const base64Payload = response.webIdentityToken.split(".")[1];
+  if (base64Payload === undefined)
+    throw new Error("failure trying to authenticate");
+
+  const payload = Buffer.from(base64Payload, "base64");
+  const decodedJWT = JSON.parse(payload.toString()) as Record<string, string>;
+
+  const accountId = decodedJWT["stedi:accountId"];
+  if (accountId === undefined)
+    throw new Error("failure trying to determine Stedi account id");
+
+  return accountId;
+};


### PR DESCRIPTION
Adds a new command to the `integrations-sdk` for migrating an existing SFTP user to a Core Stedi SFTP connection:

```shell
migrate-sftp-user <sftp-username> <partnership-id> [inbound-directory] [outbound-directory]
```