### PR TITLE
feat: update v2 transaction and fragment schemas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stedi/integrations-sdk",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stedi/integrations-sdk",
-      "version": "0.1.30",
+      "version": "0.1.31",
       "license": "ISC",
       "bin": {
         "stedi-integrations": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stedi/integrations-sdk",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "description": "Stedi Integrations SDK",
   "type": "module",
   "scripts": {

--- a/src/schemas/event-fragment-processed-v2.ts
+++ b/src/schemas/event-fragment-processed-v2.ts
@@ -1,73 +1,27 @@
 import * as z from "zod";
 import { EventHeaderSchema } from "./partial/event-header.js";
+import { EventBaseTransactionV2Schema } from "./partial/event-base-transaction-v2.js";
+
+export const CoreFragmentV2Schema = EventBaseTransactionV2Schema.extend({
+  fragmentIndex: z.number(),
+  artifacts: z
+    .array(
+      z.strictObject({
+        artifactType: z.literal("application/json"),
+        usage: z.literal("output"),
+        sizeBytes: z.number().int(),
+        url: z.string(),
+        model: z.literal("fragment"),
+      })
+    )
+    .length(1),
+});
 
 export const CoreFragmentProcessedV2EventSchema = EventHeaderSchema.extend({
   source: z.literal("stedi.core"),
   "detail-type": z.literal("fragment.processed.v2"),
   account: z.string(),
-  detail: z.strictObject({
-    direction: z.literal("INBOUND"),
-    mode: z.enum(["production", "test", "other"]),
-    fileExecutionId: z.string(),
-    transactionId: z.string(),
-    processedAt: z.string(),
-    fragments: z.strictObject({
-      batchSize: z.number(),
-      fragmentCount: z.number(),
-      keyName: z.string(),
-    }),
-    fragmentIndex: z.number(),
-    artifacts: z
-      .array(
-        z.strictObject({
-          artifactType: z.literal("application/json"),
-          usage: z.literal("output"),
-          sizeBytes: z.number().int(),
-          url: z.string(),
-          model: z.literal("fragment"),
-        })
-      )
-      .min(2),
-    partnership: z.strictObject({
-      partnershipId: z.string(),
-      partnershipType: z.literal("x12"),
-      sender: z.strictObject({ profileId: z.string() }),
-      receiver: z.strictObject({ profileId: z.string() }),
-    }),
-    x12: z.strictObject({
-      metadata: z.strictObject({
-        interchange: z.strictObject({
-          acknowledgmentRequestedCode: z.string(),
-          controlNumber: z.number().int(),
-        }),
-        functionalGroup: z.strictObject({
-          controlNumber: z.number().int(),
-          date: z.string(),
-          release: z.string(),
-          time: z.string(),
-          functionalIdentifierCode: z.string(),
-        }),
-        transaction: z.strictObject({
-          controlNumber: z.string(),
-          transactionSetIdentifier: z.string(),
-        }),
-        sender: z.strictObject({
-          applicationCode: z.string(),
-          isa: z.strictObject({ qualifier: z.string(), id: z.string() }),
-        }),
-        receiver: z.strictObject({
-          applicationCode: z.string(),
-          isa: z.strictObject({ qualifier: z.string(), id: z.string() }),
-        }),
-      }),
-      transactionSetting: z
-        .strictObject({
-          transactionSettingId: z.string(),
-          guideId: z.string().optional(),
-        })
-        .optional(),
-    }),
-  }),
+  detail: CoreFragmentV2Schema,
 });
 
 export type CoreFragmentProcessedV2Event = z.infer<

--- a/src/schemas/event-transaction-processed-v2.ts
+++ b/src/schemas/event-transaction-processed-v2.ts
@@ -1,66 +1,26 @@
 import * as z from "zod";
 import { EventHeaderSchema } from "./partial/event-header.js";
+import { EventBaseTransactionV2Schema } from "./partial/event-base-transaction-v2.js";
+
+export const CoreTransactionV2Schema = EventBaseTransactionV2Schema.extend({
+  artifacts: z
+    .array(
+      z.strictObject({
+        artifactType: z.enum(["application/edi-x12", "application/json"]),
+        usage: z.enum(["input", "output"]),
+        model: z.literal("transaction").optional(),
+        sizeBytes: z.number().int(),
+        url: z.string(),
+      })
+    )
+    .min(2),
+});
 
 export const CoreTransactionProcessedV2EventSchema = EventHeaderSchema.extend({
   source: z.literal("stedi.core"),
   "detail-type": z.literal("transaction.processed.v2"),
   account: z.string(),
-  detail: z.strictObject({
-    direction: z.enum(["INBOUND", "OUTBOUND"]),
-    mode: z.enum(["production", "test", "other"]),
-    fileExecutionId: z.string(),
-    transactionId: z.string(),
-    processedAt: z.string(),
-    artifacts: z
-      .array(
-        z.strictObject({
-          artifactType: z.enum(["application/edi-x12", "application/json"]),
-          usage: z.enum(["input", "output"]),
-          sizeBytes: z.number().int(),
-          url: z.string(),
-        })
-      )
-      .min(2),
-    partnership: z.strictObject({
-      partnershipId: z.string(),
-      partnershipType: z.literal("x12"),
-      sender: z.strictObject({ profileId: z.string() }),
-      receiver: z.strictObject({ profileId: z.string() }),
-    }),
-    x12: z.strictObject({
-      metadata: z.strictObject({
-        interchange: z.strictObject({
-          acknowledgmentRequestedCode: z.string(),
-          controlNumber: z.number().int(),
-        }),
-        functionalGroup: z.strictObject({
-          controlNumber: z.number().int(),
-          date: z.string(),
-          release: z.string(),
-          time: z.string(),
-          functionalIdentifierCode: z.string(),
-        }),
-        transaction: z.strictObject({
-          controlNumber: z.string(),
-          transactionSetIdentifier: z.string(),
-        }),
-        sender: z.strictObject({
-          applicationCode: z.string(),
-          isa: z.strictObject({ qualifier: z.string(), id: z.string() }),
-        }),
-        receiver: z.strictObject({
-          applicationCode: z.string(),
-          isa: z.strictObject({ qualifier: z.string(), id: z.string() }),
-        }),
-      }),
-      transactionSetting: z
-        .strictObject({
-          transactionSettingId: z.string(),
-          guideId: z.string().optional(),
-        })
-        .optional(),
-    }),
-  }),
+  detail: CoreTransactionV2Schema,
 });
 
 export type CoreTransactionProcessedV2Event = z.infer<

--- a/src/schemas/partial/event-base-transaction-v2.ts
+++ b/src/schemas/partial/event-base-transaction-v2.ts
@@ -1,0 +1,55 @@
+import * as z from "zod";
+
+export const EventBaseTransactionV2Schema = z.strictObject({
+  direction: z.enum(["INBOUND", "OUTBOUND"]),
+  mode: z.enum(["production", "test", "other"]),
+  fileExecutionId: z.string(),
+  transactionId: z.string(),
+  processedAt: z.string(),
+  fragments: z
+    .strictObject({
+      batchSize: z.number(),
+      fragmentCount: z.number(),
+      keyName: z.string(),
+    })
+    .nullish(),
+  partnership: z.strictObject({
+    partnershipId: z.string(),
+    partnershipType: z.literal("x12"),
+    sender: z.strictObject({ profileId: z.string() }),
+    receiver: z.strictObject({ profileId: z.string() }),
+  }),
+  x12: z.strictObject({
+    metadata: z.strictObject({
+      interchange: z.strictObject({
+        acknowledgmentRequestedCode: z.string(),
+        controlNumber: z.number().int(),
+      }),
+      functionalGroup: z.strictObject({
+        controlNumber: z.number().int(),
+        date: z.string(),
+        release: z.string(),
+        time: z.string(),
+        functionalIdentifierCode: z.string(),
+      }),
+      transaction: z.strictObject({
+        controlNumber: z.string(),
+        transactionSetIdentifier: z.string(),
+      }),
+      sender: z.strictObject({
+        applicationCode: z.string(),
+        isa: z.strictObject({ qualifier: z.string(), id: z.string() }),
+      }),
+      receiver: z.strictObject({
+        applicationCode: z.string(),
+        isa: z.strictObject({ qualifier: z.string(), id: z.string() }),
+      }),
+    }),
+    transactionSetting: z
+      .strictObject({
+        transactionSettingId: z.string().optional(),
+        guideId: z.string().optional(),
+      })
+      .optional(),
+  }),
+});


### PR DESCRIPTION
- consolidate partial base transaction schema used by fragments and transaction into shared schema
- create new top level schemas for transaction and fragment event details which can be used to parse API responses
- fix minor bugs 