### PR TITLE
feat: loosen v2 event schemas to allow for non-breaking additive changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stedi/integrations-sdk",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stedi/integrations-sdk",
-      "version": "0.1.37",
+      "version": "0.1.38",
       "license": "ISC",
       "bin": {
         "stedi-integrations": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stedi/integrations-sdk",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "description": "Stedi Integrations SDK",
   "type": "module",
   "scripts": {

--- a/src/schemas/event-file-delivered-v2.ts
+++ b/src/schemas/event-file-delivered-v2.ts
@@ -10,26 +10,35 @@ export const CoreFileDeliveredV2EventSchema = EventHeaderSchema.extend({
     processedAt: z.string(),
     artifacts: z
       .array(
-        z.strictObject({
-          artifactType: z.literal("application/edi-x12"),
-          usage: z.literal("output"),
+        z.object({
+          artifactType: z
+            .enum([
+              "application/edi-x12",
+              "application/edifact",
+              "application/filepart",
+              "application/json",
+              "application/xml",
+              "application/zip",
+              "text/csv",
+              "text/psv",
+              "text/tsv",
+              "UNKNOWN",
+            ])
+            .or(z.string()),
+          usage: z.literal("output").or(z.string()),
           sizeBytes: z.number().int(),
           url: z.string(),
         })
       )
       .min(1),
     connection: z.object({
-      connectionType: z.enum([
-        "AS2",
-        "BUCKET",
-        "SFTP",
-        "STEDI_FTP",
-        "REMOTE_FTP",
-      ]),
+      connectionType: z
+        .enum(["AS2", "BUCKET", "SFTP", "STEDI_FTP", "REMOTE_FTP"])
+        .or(z.string()),
       connectionId: z.string(),
     }),
     delivery: z.object({
-      status: z.literal("DELIVERED"),
+      status: z.literal("DELIVERED").or(z.string()),
       message: z.string(),
       artifactId: z.string(),
     }),

--- a/src/schemas/event-file-failed-v2.ts
+++ b/src/schemas/event-file-failed-v2.ts
@@ -8,35 +8,37 @@ export const CoreFileFailedV2EventSchema = EventHeaderSchema.extend({
   detail: z.object({
     fileExecutionId: z.string(),
     processedAt: z.string(),
-    direction: z.enum(["INBOUND", "OUTBOUND", "UNKNOWN"]),
+    direction: z.enum(["INBOUND", "OUTBOUND", "UNKNOWN"]).or(z.string()),
     artifacts: z
       .array(
-        z.strictObject({
-          artifactType: z.enum([
-            "application/edi-x12",
-            "application/edifact",
-            "application/filepart",
-            "application/json",
-            "application/xml",
-            "application/zip",
-            "text/csv",
-            "text/psv",
-            "text/tsv",
-            "UNKNOWN",
-          ]),
-          usage: z.enum(["input"]),
+        z.object({
+          artifactType: z
+            .enum([
+              "application/edi-x12",
+              "application/edifact",
+              "application/filepart",
+              "application/json",
+              "application/xml",
+              "application/zip",
+              "text/csv",
+              "text/psv",
+              "text/tsv",
+              "UNKNOWN",
+            ])
+            .or(z.string()),
+          usage: z.enum(["input"]).or(z.string()),
           sizeBytes: z.number().int(),
           url: z.string(),
         })
       )
       .min(1),
     errors: z.array(
-      z.strictObject({
+      z.object({
         message: z.string(),
         faultCode: z.string(),
       })
     ),
-    source: z.strictObject({
+    source: z.object({
       name: z.string(),
     }),
   }),

--- a/src/schemas/event-file-processed-v2.ts
+++ b/src/schemas/event-file-processed-v2.ts
@@ -12,26 +12,28 @@ export const CoreFileProcessedV2EventSchema = EventHeaderSchema.extend({
     connectionId: z.string().optional(),
     artifacts: z
       .array(
-        z.strictObject({
-          artifactType: z.enum([
-            "application/edi-x12",
-            "application/edifact",
-            "application/filepart",
-            "application/json",
-            "application/xml",
-            "application/zip",
-            "text/csv",
-            "text/psv",
-            "text/tsv",
-            "UNKNOWN",
-          ]),
-          usage: z.enum(["input"]),
+        z.object({
+          artifactType: z
+            .enum([
+              "application/edi-x12",
+              "application/edifact",
+              "application/filepart",
+              "application/json",
+              "application/xml",
+              "application/zip",
+              "text/csv",
+              "text/psv",
+              "text/tsv",
+              "UNKNOWN",
+            ])
+            .or(z.string()),
+          usage: z.enum(["input"]).or(z.string()),
           sizeBytes: z.number().int(),
           url: z.string(),
         })
       )
       .min(1),
-    source: z.strictObject({
+    source: z.object({
       name: z.string(),
     }),
   }),

--- a/src/schemas/event-fragment-processed-v2.ts
+++ b/src/schemas/event-fragment-processed-v2.ts
@@ -6,16 +6,16 @@ export const CoreFragmentV2Schema = EventBaseTransactionV2Schema.extend({
   fragmentIndex: z.number(),
   artifacts: z
     .array(
-      z.strictObject({
-        artifactType: z.literal("application/json"),
-        usage: z.literal("output"),
+      z.object({
+        artifactType: z.literal("application/json").or(z.string()),
+        usage: z.literal("output").or(z.string()),
         sizeBytes: z.number().int(),
         url: z.string(),
-        model: z.literal("fragment"),
+        model: z.literal("fragment").or(z.string()),
       })
     )
     .length(1),
-  fragments: z.strictObject({
+  fragments: z.object({
     batchSize: z.number(),
     fragmentCount: z.number(),
     keyName: z.string(),

--- a/src/schemas/event-transaction-processed-v2.ts
+++ b/src/schemas/event-transaction-processed-v2.ts
@@ -5,17 +5,19 @@ import { EventBaseTransactionV2Schema } from "./partial/event-base-transaction-v
 export const CoreTransactionV2Schema = EventBaseTransactionV2Schema.extend({
   artifacts: z
     .array(
-      z.strictObject({
-        artifactType: z.enum(["application/edi-x12", "application/json"]),
-        usage: z.enum(["input", "output"]),
-        model: z.literal("transaction").optional(),
+      z.object({
+        artifactType: z
+          .enum(["application/edi-x12", "application/json"])
+          .or(z.string()),
+        usage: z.enum(["input", "output"]).or(z.string()),
+        model: z.literal("transaction").or(z.string()).optional(),
         sizeBytes: z.number().int(),
         url: z.string(),
       })
     )
     .min(2),
   fragments: z
-    .strictObject({
+    .object({
       batchSize: z.number(),
       fragmentCount: z.number(),
       keyName: z.string(),

--- a/src/schemas/partial/event-base-transaction-v2.ts
+++ b/src/schemas/partial/event-base-transaction-v2.ts
@@ -1,45 +1,45 @@
 import * as z from "zod";
 
-export const EventBaseTransactionV2Schema = z.strictObject({
-  direction: z.enum(["INBOUND", "OUTBOUND"]),
-  mode: z.enum(["production", "test", "other"]),
+export const EventBaseTransactionV2Schema = z.object({
+  direction: z.enum(["INBOUND", "OUTBOUND"]).or(z.string()),
+  mode: z.enum(["production", "test", "other"]).or(z.string()),
   fileExecutionId: z.string(),
   transactionId: z.string(),
   processedAt: z.string(),
-  partnership: z.strictObject({
+  partnership: z.object({
     partnershipId: z.string(),
-    partnershipType: z.literal("x12"),
-    sender: z.strictObject({ profileId: z.string() }),
-    receiver: z.strictObject({ profileId: z.string() }),
+    partnershipType: z.literal("x12").or(z.string()),
+    sender: z.object({ profileId: z.string() }),
+    receiver: z.object({ profileId: z.string() }),
   }),
-  x12: z.strictObject({
-    metadata: z.strictObject({
-      interchange: z.strictObject({
+  x12: z.object({
+    metadata: z.object({
+      interchange: z.object({
         acknowledgmentRequestedCode: z.string(),
         controlNumber: z.number().int(),
       }),
-      functionalGroup: z.strictObject({
+      functionalGroup: z.object({
         controlNumber: z.number().int(),
         date: z.string(),
         release: z.string(),
         time: z.string(),
         functionalIdentifierCode: z.string(),
       }),
-      transaction: z.strictObject({
+      transaction: z.object({
         controlNumber: z.string(),
         transactionSetIdentifier: z.string(),
       }),
-      sender: z.strictObject({
+      sender: z.object({
         applicationCode: z.string(),
-        isa: z.strictObject({ qualifier: z.string(), id: z.string() }),
+        isa: z.object({ qualifier: z.string(), id: z.string() }),
       }),
-      receiver: z.strictObject({
+      receiver: z.object({
         applicationCode: z.string(),
-        isa: z.strictObject({ qualifier: z.string(), id: z.string() }),
+        isa: z.object({ qualifier: z.string(), id: z.string() }),
       }),
     }),
     transactionSetting: z
-      .strictObject({
+      .object({
         transactionSettingId: z.string().optional(),
         guideId: z.string().optional(),
       })


### PR DESCRIPTION
I did not loosen things like event `source`, `detail-type`, and `version`, but loosened pretty much everything else to be safe

closes: #317 