### PR TITLE
feat: allow defining a local package.json per function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stedi/integrations-sdk",
-  "version": "0.1.38",
+  "version": "0.1.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stedi/integrations-sdk",
-      "version": "0.1.38",
+      "version": "0.1.39",
       "license": "ISC",
       "bin": {
         "stedi-integrations": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stedi/integrations-sdk",
-  "version": "0.1.38",
+  "version": "0.1.39",
   "description": "Stedi Integrations SDK",
   "type": "module",
   "scripts": {

--- a/src/deploy/compile.ts
+++ b/src/deploy/compile.ts
@@ -7,6 +7,7 @@ import path from "path";
 
 export const compile = async (
   buildPath: string,
+  externals: string[] = [],
   debug = false
 ): Promise<string> => {
   const searchValue = `${path.sep}src${path.sep}`;
@@ -35,7 +36,7 @@ export const compile = async (
       js: "import { createRequire } from 'module';const require = createRequire(import.meta.url);",
     },
     mainFields: ["module", "main"],
-    external: [],
+    external: externals,
   });
 
   if (debug) {

--- a/src/deploy/compile.ts
+++ b/src/deploy/compile.ts
@@ -55,13 +55,16 @@ const pkg = {
   },
 };
 
-export const packForDeployment = async (javascriptPath: string) => {
+export const packForDeployment = async (
+  javascriptPath: string,
+  packageJSON: object | undefined
+) => {
   const dir = `${os.tmpdir()}${path.sep}idk-deploy`;
   fs.rmSync(dir, { recursive: true, force: true });
   fs.mkdirSync(dir);
   fs.writeFileSync(
     `${dir}${path.sep}package.json`,
-    JSON.stringify(pkg, null, 2)
+    JSON.stringify(packageJSON ?? pkg, null, 2)
   );
 
   const npm = process.platform === "win32" ? "npm.cmd" : "npm";

--- a/src/deploy/deploy-resources.ts
+++ b/src/deploy/deploy-resources.ts
@@ -2,7 +2,7 @@ import dotenv from "dotenv";
 import { compile, packForDeployment } from "./compile.js";
 import { createFunction, updateFunction } from "./functions.js";
 import {
-  splitFunctionNaneAndPath,
+  splitFunctionNameAndPath,
   getFunctionPaths,
   getPackageJSON,
 } from "./utils.js";
@@ -63,7 +63,7 @@ You can generate a new API key here: https://www.stedi.com/app/settings/api-keys
 
     // check if the function has a package.json
     const packageJSON = getPackageJSON(functionPath);
-    // exclude any dependencies they will be bundled into zip separately
+    // exclude any dependencies as they will be bundled into zip separately
     const externals =
       packageJSON !== undefined ? Object.keys(packageJSON.dependencies) : [];
 

--- a/src/deploy/deploy-resources.ts
+++ b/src/deploy/deploy-resources.ts
@@ -1,7 +1,11 @@
 import dotenv from "dotenv";
 import { compile, packForDeployment } from "./compile.js";
 import { createFunction, updateFunction } from "./functions.js";
-import { functionNameFromPath, getFunctionPaths } from "./utils.js";
+import {
+  splitFunctionNaneAndPath,
+  getFunctionPaths,
+  getPackageJSON,
+} from "./utils.js";
 import { waitUntilFunctionCreateComplete } from "@stedi/sdk-client-functions";
 
 import { functionsClient } from "../clients/functions.js";
@@ -53,13 +57,16 @@ You can generate a new API key here: https://www.stedi.com/app/settings/api-keys
   const functionPaths = getFunctionPaths(pathMatch);
 
   const promises: Promise<unknown>[] = functionPaths.map(async (fnPath) => {
-    const functionName = functionNameFromPath(fnPath);
+    const { functionPath, functionName } = splitFunctionNaneAndPath(fnPath);
 
     console.log(`Deploying ${functionName}`);
 
     // compiling function code
     const jsPath = await compile(fnPath);
-    const code = await packForDeployment(jsPath);
+
+    const packageJSON = getPackageJSON(functionPath);
+
+    const code = await packForDeployment(jsPath, packageJSON);
 
     // deploying functions
     try {

--- a/src/deploy/deploy-resources.ts
+++ b/src/deploy/deploy-resources.ts
@@ -61,10 +61,14 @@ You can generate a new API key here: https://www.stedi.com/app/settings/api-keys
 
     console.log(`Deploying ${functionName}`);
 
-    // compiling function code
-    const jsPath = await compile(fnPath);
-
+    // check if the function has a package.json
     const packageJSON = getPackageJSON(functionPath);
+    // exclude any dependencies they will be bundled into zip separately
+    const externals =
+      packageJSON !== undefined ? Object.keys(packageJSON.dependencies) : [];
+
+    // compiling function code
+    const jsPath = await compile(fnPath, externals, false);
 
     const code = await packForDeployment(jsPath, packageJSON);
 

--- a/src/deploy/utils.ts
+++ b/src/deploy/utils.ts
@@ -6,17 +6,37 @@ interface ResourceFile {
   fileName?: string;
 }
 
-export const functionNameFromPath = (fnPath: string): string => {
+export const getPackageJSON = (pathName: string): undefined | object => {
+  const packagePath = path.join(pathName, "package.json");
+
+  if (fs.existsSync(packagePath)) {
+    try {
+      return JSON.parse(fs.readFileSync(packagePath, "utf-8")) as object;
+    } catch (err) {
+      // swallow the error, a package.json is optional
+    }
+  }
+
+  return undefined;
+};
+
+export const splitFunctionNaneAndPath = (
+  fnPath: string
+): { functionPath: string; functionName: string } => {
   // get function name excluding extension
   // path-a/path-b/path-never-ends/nice/function/handler.ts
   // => nice-function
-  const functionName = fnPath.split(path.sep).slice(-3, -1).join("-");
+  const pathParts = fnPath.split(path.sep);
+  let functionName = pathParts.slice(-3, -1).join("-");
 
   // path-a/functions/my-func/handler.ts
   // => my-func
-  if (functionName.startsWith("functions-")) return functionName.slice(10);
+  if (functionName.startsWith("functions-"))
+    functionName = functionName.slice(10);
 
-  return functionName;
+  const functionPath = pathParts.slice(0, -1).join(path.sep);
+
+  return { functionPath, functionName };
 };
 
 export const getFunctionPaths = (pathMatch?: string) => {

--- a/src/deploy/utils.ts
+++ b/src/deploy/utils.ts
@@ -6,12 +6,20 @@ interface ResourceFile {
   fileName?: string;
 }
 
-export const getPackageJSON = (pathName: string): undefined | object => {
+interface SimplePackageJSON {
+  dependencies: Record<string, string>;
+}
+
+export const getPackageJSON = (
+  pathName: string
+): undefined | SimplePackageJSON => {
   const packagePath = path.join(pathName, "package.json");
 
   if (fs.existsSync(packagePath)) {
     try {
-      return JSON.parse(fs.readFileSync(packagePath, "utf-8")) as object;
+      return JSON.parse(
+        fs.readFileSync(packagePath, "utf-8")
+      ) as SimplePackageJSON;
     } catch (err) {
       // swallow the error, a package.json is optional
     }

--- a/src/deploy/utils.ts
+++ b/src/deploy/utils.ts
@@ -16,19 +16,15 @@ export const getPackageJSON = (
   const packagePath = path.join(pathName, "package.json");
 
   if (fs.existsSync(packagePath)) {
-    try {
-      return JSON.parse(
-        fs.readFileSync(packagePath, "utf-8")
-      ) as SimplePackageJSON;
-    } catch (err) {
-      // swallow the error, a package.json is optional
-    }
+    return JSON.parse(
+      fs.readFileSync(packagePath, "utf-8")
+    ) as SimplePackageJSON;
   }
 
   return undefined;
 };
 
-export const splitFunctionNaneAndPath = (
+export const splitFunctionNameAndPath = (
   fnPath: string
 ): { functionPath: string; functionName: string } => {
   // get function name excluding extension

--- a/src/plugins/buildFailureFromHTTPResponse.ts
+++ b/src/plugins/buildFailureFromHTTPResponse.ts
@@ -1,0 +1,22 @@
+import { Response } from "node-fetch";
+import {
+  StediPluginInvocationEventBase,
+  failureResponse,
+} from "@stedi/integrations-sdk/plugins";
+
+export const buildFailureFromHTTPResponse = async (
+  invocationIds: StediPluginInvocationEventBase,
+  response: Response
+) => {
+  return failureResponse({
+    invocationIds,
+    message: "API returned a non-200 response.",
+    details: {
+      status: response.status,
+      statusText: response.statusText,
+      body: response.headers.get("content-type")?.includes("json")
+        ? await response.json()
+        : await response.text(),
+    },
+  });
+};

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -1,3 +1,4 @@
 export * from "./types.js";
 export * from "./responses/successResponse.js";
 export * from "./responses/failureResponse.js";
+export * from "./buildFailureFromHTTPResponse.js";

--- a/src/plugins/responses/failureResponse.ts
+++ b/src/plugins/responses/failureResponse.ts
@@ -3,11 +3,17 @@ import {
   StediPluginInvocationResult,
 } from "../types.js";
 
-export const failureResponse = (
-  invocationIds: StediPluginInvocationIdentifiers,
-  message: string,
-  details?: Record<string, unknown>
-): StediPluginInvocationResult => {
+interface FailureResponseParams {
+  invocationIds: StediPluginInvocationIdentifiers;
+  message: string;
+  details?: Record<string, unknown>;
+}
+
+export const failureResponse = ({
+  invocationIds,
+  message,
+  details,
+}: FailureResponseParams): StediPluginInvocationResult => {
   return {
     invocationId: invocationIds.invocationId,
     namespace: invocationIds.namespace,

--- a/src/plugins/responses/successResponse.ts
+++ b/src/plugins/responses/successResponse.ts
@@ -3,17 +3,26 @@ import {
   StediPluginInvocationResult,
 } from "../types.js";
 
-export const successResponse = (
-  invocationIds: StediPluginInvocationIdentifiers,
-  output: unknown[],
-  logs: StediPluginInvocationResult["logs"] = []
-): StediPluginInvocationResult => {
+interface SuccessResponseParams {
+  invocationIds: StediPluginInvocationIdentifiers;
+  output?: unknown[];
+  state?: Record<string, unknown>;
+  logs?: StediPluginInvocationResult["logs"];
+}
+
+export const successResponse = ({
+  invocationIds,
+  output,
+  state,
+  logs = [],
+}: SuccessResponseParams): StediPluginInvocationResult => {
   return {
     invocationId: invocationIds.invocationId,
     namespace: invocationIds.namespace,
     operationName: invocationIds.operationName,
     configurationId: invocationIds.configurationId,
     status: "SUCCESS",
+    state,
     logs,
     output,
   };

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -24,4 +24,5 @@ export type StediPluginInvocationResult = StediPluginInvocationIdentifiers & {
   status: "SUCCESS" | "ERROR";
   output?: unknown[];
   logs?: StediPluginInvocationLog[];
+  state?: Record<string, unknown>;
 };


### PR DESCRIPTION
This allows each function to control what packages will be installed and included in their zip file at deploy time.

Previously this was hardcoded inside the deploy logic, which is still the fallback.