### PR TITLE
feat: remove unused event binding code

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stedi/integrations-sdk",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Stedi Integrations SDK",
   "type": "module",
   "scripts": {

--- a/src/deploy/functions.ts
+++ b/src/deploy/functions.ts
@@ -1,4 +1,3 @@
-import { DocumentType } from "@aws-sdk/types";
 import { PutObjectCommand } from "@stedi/sdk-client-buckets";
 import {
   CreateFunctionCommand,
@@ -10,11 +9,6 @@ import {
 } from "@stedi/sdk-client-functions";
 import { bucketsClient } from "../clients/buckets.js";
 import { functionsClient } from "../clients/functions.js";
-import {
-  CreateEventToFunctionBindingCommand,
-  UpdateEventToFunctionBindingCommand,
-} from "@stedi/sdk-client-events";
-import { eventsClient } from "../clients/events.js";
 
 const sharedPackageBucketName =
   process.env.USE_PREVIEW === undefined
@@ -86,34 +80,6 @@ export const deleteFunction = async (
   return functionsClient().send(
     new DeleteFunctionCommand({
       functionName,
-    })
-  );
-};
-
-export const createFunctionEventBinding = async (
-  functionName: string,
-  eventPattern: DocumentType,
-  eventToFunctionBindingName: string
-) => {
-  return eventsClient().send(
-    new CreateEventToFunctionBindingCommand({
-      eventPattern,
-      functionName,
-      eventToFunctionBindingName,
-    })
-  );
-};
-
-export const updateFunctionEventBinding = async (
-  functionName: string,
-  eventPattern: DocumentType,
-  eventToFunctionBindingName: string
-) => {
-  return eventsClient().send(
-    new UpdateEventToFunctionBindingCommand({
-      eventPattern,
-      functionName,
-      eventToFunctionBindingName,
     })
   );
 };


### PR DESCRIPTION
The associated commands have been remove from the new Events API / SDK combo, it appears this code isn't used by `integrations-sdk` directly.