### PR TITLE
chore: undici upgrade to fix the dependabot alert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "prettier": "2.8.8",
         "ts-node": "10.9.2",
         "typescript": "5.6.3",
-        "undici": "5.28.4",
+        "undici": "5.28.5",
         "yargs": "17.7.2",
         "zod": "3.23.8"
       }
@@ -10413,9 +10413,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.28.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
-      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
+      "version": "5.28.5",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.5.tgz",
+      "integrity": "sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==",
       "dev": true,
       "dependencies": {
         "@fastify/busboy": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "prettier": "2.8.8",
     "ts-node": "10.9.2",
     "typescript": "5.6.3",
-    "undici": "5.28.4",
+    "undici": "5.28.5",
     "yargs": "17.7.2",
     "zod": "3.23.8"
   },


### PR DESCRIPTION
[Use of Insufficiently Random Values in undici](https://github.com/Stedi-Demos/integrations-sdk/security/dependabot/19)